### PR TITLE
Skips an Australian publisher

### DIFF
--- a/author_list.py
+++ b/author_list.py
@@ -28,6 +28,15 @@ def get_books(key, author_obj):
                 continue
             if when == None:
                 raise Exception(book)
+            publisher = book.find("publisher")
+            if publisher is not None:
+                publisher = publisher.text
+                if publisher is None:
+                    publisher = ""
+            else:
+                publisher = ""
+            if publisher == "HarperCollins - AU": # FIXME: just skips an Australian publisher, because there's no data on publisher regions
+                continue
             if title not in all_books or (when !=None and all_books[title]["when"] > when):
                 all_books[title] = {"when": when, "id": int(book.find("id").text), "edition": edition}
         if len(books) == 30:


### PR DESCRIPTION
Hacky fix for https://github.com/palfrey/tailgate/issues/35. Really, we want "here's the per-region dates" for things, but right now we have no data on what region a book got published in, and so this is a hacky workaround so I don't get early AU dates for things.